### PR TITLE
Register the virtual key command for the right control key.

### DIFF
--- a/_generic_edit.py
+++ b/_generic_edit.py
@@ -29,6 +29,12 @@ from dragonfly import (
     CompoundRule
 )
 
+import win32con
+from dragonfly.actions.keyboard import Typeable
+from dragonfly.actions.typeables import typeables
+
+typeables["Control_R"] = Typeable(code=win32con.VK_RCONTROL, name="Control_R")
+
 aeneaPath = r"E:\dev\projects\aenea\util"  # ToDo: move to configuration.
 if not aeneaPath in sys.path:
     sys.path.insert(0, aeneaPath)


### PR DESCRIPTION
This fixes a load error I was receiving due to the change made in 839ccb1a22d0c0e70cf76922c356882ba668d5ca.  Since "Control_R" wasn't a defined typeable key, dragonfly would fail to load the grammar properly.

Note I wasn't able to test this out, but the grammar loads now and it seems to be doing the same thing dragonfly does in defining its key bindings.
