### PR TITLE
Update to use the current version of Aenea.

### DIFF
--- a/_app_eclipse.py
+++ b/_app_eclipse.py
@@ -16,7 +16,7 @@ from lib.dynamic_aenea import (
     Key,
 )
 
-from proxy_nicknames import AppContext as NixAppContext
+from aenea import ProxyAppContext as NixAppContext
 
 
 rules = MappingRule(

--- a/_app_ff_chrome_opera.py
+++ b/_app_ff_chrome_opera.py
@@ -18,7 +18,7 @@ from lib.dynamic_aenea import (
     Key,
 )
 
-from proxy_nicknames import AppContext as NixAppContext
+from aenea import ProxyAppContext as NixAppContext
 
 
 mapping = {

--- a/_app_hipchat.py
+++ b/_app_hipchat.py
@@ -13,7 +13,8 @@ from lib.dynamic_aenea import (
     Text,
 )
 
-from proxy_nicknames import AppContext as NixAppContext
+from aenea import ProxyAppContext as NixAppContext
+
 
 hipchat_config = Config("HipChat")
 hipchat_config.usernames = Section("Username Mappings")

--- a/_app_intellij.py
+++ b/_app_intellij.py
@@ -16,7 +16,8 @@ from lib.dynamic_aenea import (
 
 import lib.format
 
-from proxy_nicknames import AppContext as NixAppContext
+from aenea import ProxyAppContext as NixAppContext
+
 
 mapping = {
     # Code execution.

--- a/_app_terminator.py
+++ b/_app_terminator.py
@@ -12,9 +12,9 @@ from dragonfly import AppContext, Function, Grammar, IntegerRef, Key, MappingRul
 import lib.config
 config = lib.config.get_config()
 if config.get("aenea.enabled", False) == True:
-    from proxy_nicknames import Key  # @Reimport
-    from proxy_nicknames import AppContext as NixAppContext
-    import aenea
+    from aenea import ProxyAppContext as NixAppContext
+    from aenea import ProxyKey as Key
+    import aenea.config
 
 rules = MappingRule(
     mapping = {
@@ -76,7 +76,7 @@ rules = MappingRule(
 
 # This is a Linux-only application, so only enable the grammar if Aenea is enabled.
 if config.get("aenea.enabled", False) == True:
-    context = aenea.global_context & NixAppContext(executable="terminator")
+    context = aenea.config.proxy_enable_context & NixAppContext(executable="terminator")
 
     grammar = Grammar("Terminator general", context=context)
     grammar.add_rule(rules)

--- a/_unity.py
+++ b/_unity.py
@@ -21,9 +21,8 @@ if config.get("aenea.enabled", False) == True:
         Choice
     )
 
-    from proxy_nicknames import Key, Mouse
-    from proxy_actions import communication
-    import aenea
+    from aenea.lax import Key, Mouse
+    import aenea.config
 
     def window_direction(winDirection):
         try:
@@ -94,11 +93,11 @@ if config.get("aenea.enabled", False) == True:
     }
 
     def toggle_host_server():
-        communication.toggle_server()
+        aenea.communications.server.toggle_server()
 
     def switch_to_window(text):
         txt = str(text).lower()
-        communication.server.switch_to_window(txt)
+        aenea.communications.server.server.switch_to_window(txt)
 
     rules = MappingRule(
         mapping={
@@ -148,7 +147,7 @@ if config.get("aenea.enabled", False) == True:
         }
     )
 
-    grammar = Grammar("Unity desktop grammar", context=aenea.global_context)
+    grammar = Grammar("Unity desktop grammar", context=aenea.config.proxy_enable_context)
     grammar.add_rule(rules)
     grammar.load()
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -34,13 +34,15 @@ WORKING_PATH = os.path.split(os.path.dirname(os.path.abspath(__file__)))[0]
 CONFIG_PATH = os.path.join(WORKING_PATH, "config.json")
 CONFIG = {}  # Empty, default config.
 
+GRAMMAR_CONFIG_PATH = os.path.join(WORKING_PATH, "grammars")
+
 
 def save_config():
     global CONFIG
     global CONFIG_PATH
     try:
         configData = json.dumps(CONFIG, sort_keys=True, indent=4,
-            ensure_ascii=False)
+                                ensure_ascii=False)
         with open(CONFIG_PATH, "w+") as f:
             f.write(configData)  # Save config to file.
     except Exception as e:
@@ -53,12 +55,14 @@ def load_config():
     try:
         if os.path.isfile(CONFIG_PATH):  # If the config file exists.
             with open(CONFIG_PATH, "r") as f:
-                CONFIG = json.loads(f.read())  # Load saved configuration.
+                CONFIG = json.load(f)  # Load saved configuration.
                 init_default_values()
         else:  # If the config file does not exist.
             save_config()  # Save the default config to file.
     except Exception as e:
         print("Could not load config file: %s" % str(e))
+
+
 
 
 def init_default_values():

--- a/lib/dynamic_aenea.py
+++ b/lib/dynamic_aenea.py
@@ -1,4 +1,4 @@
-import aenea, dragonfly, proxy_actions, lib.config
+import aenea, dragonfly, aenea.proxy_actions, lib.config
 config = lib.config.get_config()
 
 def should_send_to_aenea():
@@ -9,7 +9,7 @@ def should_send_to_aenea():
     if config.get("aenea.enabled", False) == True:
         win = dragonfly.Window.get_foreground()
 
-        return aenea.global_context.matches(win.executable, win.title, win.handle)
+        return aenea.config.proxy_enable_context.matches(win.executable, win.title, win.handle)
     else:
         return False
 
@@ -44,7 +44,7 @@ class GlobalDynamicContext(DynamicContext):
     """A dynamic context implementation that allows commands to be processed in any remote application if Aenea is
     enabled and any local application if Aenea is disabled."""
     def __init__(self):
-        DynamicContext.__init__(self, None, aenea.global_context)
+        DynamicContext.__init__(self, None, aenea.config.proxy_enable_context)
 
 
 class DynamicAction:
@@ -90,12 +90,12 @@ class DynamicAction:
 
 class Key(DynamicAction):
     def __init__(self, spec=None, static=False):
-        DynamicAction.__init__(self, dragonfly.Key(spec, static), proxy_actions.ProxyKey(spec, static))
+        DynamicAction.__init__(self, dragonfly.Key(spec, static), aenea.proxy_actions.ProxyKey(spec, static))
 
 
 class Text(DynamicAction):
     def __init__(self, spec=None, static=False, pause=0.02, autofmt=False):
-        DynamicAction.__init__(self, dragonfly.Text(spec, static, pause, autofmt), proxy_actions.ProxyText(spec, static))
+        DynamicAction.__init__(self, dragonfly.Text(spec, static, pause, autofmt), aenea.proxy_actions.ProxyText(spec, static))
 
 
 # This is a gigantic hack.  dragonfly.ActionBase performs an `isinstance` check on the supplied action to make

--- a/lib/grid_base_x.py
+++ b/lib/grid_base_x.py
@@ -3,8 +3,7 @@ import Tkinter as tk
 from Tkconstants import *  # @UnusedWildImport
 import time
 
-from proxy_actions import communication
-
+import aenea.communications
 
 class GridConfig:
     def __init__(self, positionX=0, positionY=0, width=1024, height=768,
@@ -247,7 +246,7 @@ def mouse_grid(pos1=None, pos2=None, pos3=None, pos4=None, pos5=None,
         attributes["pos9"] = pos9
     if action:
         attributes["action"] = action
-    communication.server.mouse_grid_dispatcher(params)
+    aenea.communications.server.mouse_grid_dispatcher(params)
 
 
 def hide_grids(excludePosition=None):
@@ -258,7 +257,7 @@ def hide_grids(excludePosition=None):
 
     """
     params = {"do": "hide_grids"}
-    communication.server.mouse_grid_dispatcher(params)
+    aenea.communications.server.mouse_grid_dispatcher(params)
     disable_navigation_grammar()
 
 
@@ -297,13 +296,13 @@ def mouse_pos(pos1, pos2=None, pos3=None, pos4=None, pos5=None, pos6=None,
         attributes["pos9"] = pos9
     if action:
         attributes["action"] = action
-    communication.server.mouse_grid_dispatcher(params)
+    aenea.communications.server.mouse_grid_dispatcher(params)
 
 
 def go():
     """Places the mouse at the grid coordinates. Hides the grid."""
     params = {"do": "go"}
-    communication.server.mouse_grid_dispatcher(params)
+    aenea.communications.server.mouse_grid_dispatcher(params)
     disable_navigation_grammar()
 
 
@@ -313,7 +312,7 @@ def left_click():
 
     """
     params = {"do": "left_click"}
-    communication.server.mouse_grid_dispatcher(params)
+    aenea.communications.server.mouse_grid_dispatcher(params)
     disable_navigation_grammar()
 
 
@@ -323,7 +322,7 @@ def right_click():
 
     """
     params = {"do": "right_click"}
-    communication.server.mouse_grid_dispatcher(params)
+    aenea.communications.server.mouse_grid_dispatcher(params)
     disable_navigation_grammar()
 
 
@@ -333,7 +332,7 @@ def double_click():
 
     """
     params = {"do": "double_click"}
-    communication.server.mouse_grid_dispatcher(params)
+    aenea.communications.server.mouse_grid_dispatcher(params)
     disable_navigation_grammar()
 
 
@@ -343,7 +342,7 @@ def control_click():
 
     """
     params = {"do": "control_click"}
-    communication.server.mouse_grid_dispatcher(params)
+    aenea.communications.server.mouse_grid_dispatcher(params)
     disable_navigation_grammar()
 
 
@@ -353,7 +352,7 @@ def shift_click():
 
     """
     params = {"do": "shift_click"}
-    communication.server.mouse_grid_dispatcher(params)
+    aenea.communications.server.mouse_grid_dispatcher(params)
     disable_navigation_grammar()
 
 
@@ -363,7 +362,7 @@ def mouse_mark():
 
     """
     params = {"do": "mouse_mark"}
-    communication.server.mouse_grid_dispatcher(params)
+    aenea.communications.server.mouse_grid_dispatcher(params)
     disable_navigation_grammar()
 
 
@@ -373,5 +372,5 @@ def mouse_drag():
 
     """
     params = {"do": "mouse_drag"}
-    communication.server.mouse_grid_dispatcher(params)
+    aenea.communications.server.mouse_grid_dispatcher(params)
     disable_navigation_grammar()


### PR DESCRIPTION
This PR makes the minimal changes necessary to get dragonfly-scripts working with the current version of Aenea. It does nothing to address duplication of effort or responsibility between dynamic_aenea and the Platform* actions/contexts. I have done basic testing, but don't have the platform to test much of the Windows-specific functionality/applications -- I use my VM as a dumb voice box and nothing more. I've verified that all modules load, that dynamics work for basic operations, for both remote and proxy.

I'm not going to merge this myself since I can't test that it works correctly in a Windows dev environment, its primary habitat:-)